### PR TITLE
Adding back phantomjs as a requirement for headless browser testing. …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 install:
 - phpenv rehash
 sudo: required
+cache: yarn
 before_script:
 - echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
 - wget http://dev.mysql.com/get/mysql-apt-config_0.7.3-1_all.deb
@@ -27,9 +28,9 @@ before_script:
 - cp config/deploy.sample.php config/deploy.php
 - composer self-update
 - composer install
-- npm install -g bower
-- bower install
-- bin/cradle faucet install -f --skip-configs
+- bin/cradle install -f --skip-configs
+- bin/cradle sql populate
+- yarn build
 - php -S 127.0.0.1:8888 -t ./public >/dev/null 2>&1 &
 - bin/phantomjs --webdriver=4444 >/dev/null 2>&1 &
 script:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "cradlephp/cradle-role": "~2.2.0",
         "cradlephp/cradle-api": "~2.2.0",
         "cradlephp/cradle-history": "~2.2.0",
-        "cradlephp/cradle-install": "~2.2.0"
+        "cradlephp/cradle-install": "~2.2.0",
+        "jakoch/phantomjs-installer": "2.1.1-p07"
     },
     "autoload": {
         "psr-4": {
@@ -29,5 +30,13 @@
     },
     "config": {
         "bin-dir": "bin"
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "PhantomInstaller\\Installer::installPhantomJS"
+        ],
+        "post-update-cmd": [
+            "PhantomInstaller\\Installer::installPhantomJS"
+        ]
     }
 }


### PR DESCRIPTION
…Puppeteer requires node and we want to minimize as best as possible the need for another language.